### PR TITLE
Fixes padding of node items, scrolling of sidebar and position of overlay edit button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-sidekick",
-  "version": "0.0.9",
+  "version": "0.1.1",
   "description": "Chrome Extension that enables inline editing for websites created in Contentful",
   "main": "index.js",
   "browserslist": [

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -3,18 +3,8 @@
   "name": "Contentful Sidekick",
   "short_name": "Contentful Sidekick",
   "description": "Chrome Extension that enables inline editing for websites created in Contentful",
-  "version": "0.0.9",
-  "permissions": [
-    "activeTab",
-    "cookies",
-    "identity",
-    "storage",
-    "tabs",
-    "history",
-    "http://*/*",
-    "https://*/*",
-    "*://*/*"
-  ],
+  "version": "0.1.1",
+  "permissions": ["activeTab", "storage", "tabs", "http://*/*", "https://*/*", "*://*/*"],
   "icons": {
     "16": "img/icon16.png",
     "32": "img/icon32.png",

--- a/src/shared/css/content.css
+++ b/src/shared/css/content.css
@@ -144,7 +144,7 @@ body {
   display: inline-block;
   position: absolute;
   z-index: 10000000;
-  transform: translate(0%, -100%);
+  /* transform: translate(0%, -100%); */
   padding: 2px 6px 1px;
   background-color: #00a7f7;
   border-radius: 0;

--- a/src/shared/js/components/Sidekick/Sidekick.css
+++ b/src/shared/js/components/Sidekick/Sidekick.css
@@ -9,16 +9,16 @@
   width: 20vw;
   height: 100vh;
   max-height: 100vh;
-  /* overflow-y: auto; */
-  background-color: #F6F9FC;
-  box-shadow: 0 0 7px 0 rgba(0,0,0,0.2);
+  overflow-y: auto;
+  background-color: #f6f9fc;
+  box-shadow: 0 0 7px 0 rgba(0, 0, 0, 0.2);
   color: #111;
   font-family: 'Kumbh Sans', Verdana, sans-serif;
   font-size: 13px;
   line-height: 2rem;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  transition: transform .5s;
+  transition: transform 0.5s;
   transform: translateX(-100%);
 }
 [data-init-csk] .csk-element-sidebar.show {
@@ -63,10 +63,11 @@
   color: #111;
   line-height: 2;
   user-select: none;
-  transition: .3s;
+  transition: 0.3s;
 }
 
- .csk-element-sidebar .csk-item-group.selected, .csk-element-sidebar .csk-item-group:hover {
+.csk-element-sidebar .csk-item-group.selected,
+.csk-element-sidebar .csk-item-group:hover {
   background-color: #ececec;
 }
 
@@ -78,6 +79,10 @@
 .csk-element-sidebar .csk-item:focus,
 .csk-element-sidebar .csk-icon-expand:focus {
   outline: none;
+}
+
+.csk-sidebar-node {
+  padding: 0 0;
 }
 
 .csk-sidebar-node .csk-icon-expand:before {
@@ -182,7 +187,7 @@
   box-shadow: 1px 1px 10px 0px #00000024;
   border-radius: 2px;
   opacity: 0;
-  transition: .3s;
+  transition: 0.3s;
   width: 170px;
   font-size: 12px;
 }


### PR DESCRIPTION
### Description
This PR fixes some minor issues with the sidekick UI. 
- Force no padding on node elements that was conflicting with some sites
- Adds scrollbar to sidebar when expanding many items
- Moves the edit button into the blur container to make it always reachable

### Screenshots
![image](https://user-images.githubusercontent.com/9321946/120001886-a1831500-bfaa-11eb-80d2-c7b67098ed46.png)
