### PR TITLE
LRFA-1511 - Fix sidekick styles from messing with styles on other sites

### DIFF
--- a/src/shared/js/components/Sidekick/Sidekick.css
+++ b/src/shared/js/components/Sidekick/Sidekick.css
@@ -1,10 +1,5 @@
 /* Sidekick sidebar styles */
 @import url('https://fonts.googleapis.com/css2?family=Kumbh+Sans&display=swap');
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
 .csk-element-sidebar {
   z-index: 1000000;
   position: fixed;


### PR DESCRIPTION
Found that the global styles in Sidekick.css were the styles causing the issues.

I removed these global styles.

To test:

1. Pull down repo and run a build:  `yarn build:chrome`
2. Use the newly created `chrome` folder in the `dist` folder that was just created and load the unpacked extension
3. Enabled the extension
4. Go to gmail, docs, and calendar sites with sidekick enabled
5. Should not see any changes to these other sites